### PR TITLE
SDIT-983 Use correct token for /ids endpoints

### DIFF
--- a/server/services/nomisMigrationService.ts
+++ b/server/services/nomisMigrationService.ts
@@ -361,9 +361,8 @@ export default class NomisMigrationService {
   }
 
   async getActivitiesMigrationEstimatedCount(filter: GetActivitiesByFilter, context: Context): Promise<number> {
-    const token = await this.hmppsAuthClient.getSystemClientToken(context.username)
     logger.info(`getting details for activities migration estimated count`)
-    const response = await NomisMigrationService.restClient(token).get<PageActivitiesIdResponse>({
+    const response = await NomisMigrationService.restClient(context.token).get<PageActivitiesIdResponse>({
       path: `/migrate/activities/ids`,
       query: `${querystring.stringify({ ...filter, size: 1 })}`,
     })
@@ -446,9 +445,8 @@ export default class NomisMigrationService {
   }
 
   async getAllocationsMigrationEstimatedCount(filter: GetAllocationsByFilter, context: Context): Promise<number> {
-    const token = await this.hmppsAuthClient.getSystemClientToken(context.username)
     logger.info(`getting details for allocations migration estimated count`)
-    const response = await NomisMigrationService.restClient(token).get<PageAllocationsIdResponse>({
+    const response = await NomisMigrationService.restClient(context.token).get<PageAllocationsIdResponse>({
       path: `/migrate/allocations/ids`,
       query: `${querystring.stringify({ ...filter, size: 1 })}`,
     })


### PR DESCRIPTION
These endpoints are in the migration service (unlike for other migrations which call endpoints in Nomis prisoner API). So we need to use the user token which should have the `MIGRATE_ACTIVITIES` role rather than the system token which doesn't know about the `MIGRATE_*` roles (because it's used for calling Nomis prisoner API).