### PR TITLE
SDIT-1351 Add allocation missing pay bands check

### DIFF
--- a/assets/js/page-enhancements.js
+++ b/assets/js/page-enhancements.js
@@ -16,7 +16,7 @@ window.pageEnhancements = (($, document) => {
       const text = document.getElementById(textAreaId).value
       await navigator.clipboard.writeText(text)
     }
-    const copyLinkPrefixes = ['copy-suspended']
+    const copyLinkPrefixes = ['copy-suspended', 'copy-missing-pay-band']
     copyLinkPrefixes.forEach(prefix => {
       const copyLink = document.getElementById(`${prefix}-link`)
       const copyTextArea = document.getElementById(`${prefix}-text`)
@@ -35,7 +35,6 @@ window.pageEnhancements = (($, document) => {
   return {
     init: () => {
       $(() => {
-        console.log('initiating page enhancements')
         copyTextToClipboard()
       })
     },

--- a/assets/js/page-enhancements.js
+++ b/assets/js/page-enhancements.js
@@ -12,18 +12,35 @@ window.pageEnhancements = (($, document) => {
     if (!document.getElementById('startActivitiesMigrationPreviewPage')) {
       return
     }
-    async function copyText(textAreaId) {
-      const text = document.getElementById(textAreaId).value
-      await navigator.clipboard.writeText(text)
-    }
     const copyLinkPrefixes = ['copy-suspended', 'copy-missing-pay-band']
+
+    async function copyText(copyLinkPrefix) {
+      clearConfirmations()
+      const text = document.getElementById(`${copyLinkPrefix}-text`).value
+      await navigator.clipboard
+        .writeText(text)
+        .then(() => {
+          document.getElementById(`${copyLinkPrefix}-confirmed`).classList.remove('govuk-visually-hidden')
+        })
+        .catch(() => {
+          document.getElementById(`${copyLinkPrefix}-failed`).classList.remove('govuk-visually-hidden')
+        })
+    }
+
+    function clearConfirmations() {
+      copyLinkPrefixes.forEach(prefix => {
+        document.getElementById(`${prefix}-confirmed`).classList.add('govuk-visually-hidden')
+        document.getElementById(`${prefix}-failed`).classList.add('govuk-visually-hidden')
+      })
+    }
+
     copyLinkPrefixes.forEach(prefix => {
       const copyLink = document.getElementById(`${prefix}-link`)
       const copyTextArea = document.getElementById(`${prefix}-text`)
       if (copyLink) {
         if (navigator.clipboard && copyTextArea) {
           copyLink.addEventListener('click', async () => {
-            await copyText(`${prefix}-text`)
+            await copyText(prefix)
           })
         } else {
           copyLink.classList.add('govuk-visually-hidden')

--- a/integration_tests/e2e/startActivitiesMigration.cy.ts
+++ b/integration_tests/e2e/startActivitiesMigration.cy.ts
@@ -125,6 +125,7 @@ context('Start Activities Migration', () => {
       cy.task('stubGetDpsPayBands')
       cy.task('stubGetDpsPrisonRegime')
       cy.task('stubFindSuspendedAllocations')
+      cy.task('stubFindAllocationsWithMissingPayBands')
 
       const page = Page.verifyOnPage(StartActivitiesMigrationPage)
       page.prisonId().type('MDI')
@@ -139,6 +140,7 @@ context('Start Activities Migration', () => {
       previewPage.dpsPayBands().should('exist')
       previewPage.dpsPrisonRegime().should('exist')
       previewPage.nomisSuspendedAllocations().should('exist')
+      previewPage.nomisAllocationsWithNoPayBands().should('exist')
     })
 
     it('Shows errors returned from preview checks', () => {
@@ -157,6 +159,7 @@ context('Start Activities Migration', () => {
       cy.task('stubGetDpsPayBandsErrors')
       cy.task('stubGetDpsPrisonRegimeErrors')
       cy.task('stubFindSuspendedAllocationsErrors')
+      cy.task('stubFindAllocationsWithMissingPayBandsErrors')
 
       const page = Page.verifyOnPage(StartActivitiesMigrationPage)
       page.prisonId().type('MDI')
@@ -169,12 +172,14 @@ context('Start Activities Migration', () => {
       previewPage.errorSummary().contains('Failed to check if prison MDI has pay bands in DPS')
       previewPage.errorSummary().contains('Failed to check if prison MDI has slot times configured in DPS')
       previewPage.errorSummary().contains('Failed to find suspended allocations')
+      previewPage.errorSummary().contains('Failed to find allocations with missing pay bands')
       previewPage.nomisFeatureSwitch().should('not.exist')
       previewPage.activateFeatureSwitch().should('not.exist')
       previewPage.dpsFeatureSwitch().should('not.exist')
       previewPage.dpsPayBands().should('not.exist')
       previewPage.dpsPrisonRegime().should('not.exist')
       previewPage.nomisSuspendedAllocations().should('not.exist')
+      previewPage.nomisAllocationsWithNoPayBands().should('not.exist')
     })
 
     it('Turns on NOMIS feature switch if not already active', () => {
@@ -192,6 +197,7 @@ context('Start Activities Migration', () => {
       cy.task('stubGetDpsPayBands')
       cy.task('stubGetDpsPrisonRegime')
       cy.task('stubFindSuspendedAllocations')
+      cy.task('stubFindAllocationsWithMissingPayBands')
       cy.task('stubCheckServiceAgencySwitchNotFound')
       cy.task('stubPostServiceAgencySwitch')
       cy.task('stubCheckServiceAgencySwitchAfterNotFound')

--- a/integration_tests/mockApis/nomisPrisonerApi.ts
+++ b/integration_tests/mockApis/nomisPrisonerApi.ts
@@ -313,6 +313,37 @@ const stubFindSuspendedAllocationsErrors = (): SuperAgentRequest =>
     },
   })
 
+const stubFindAllocationsWithMissingPayBands = (): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/nomis-prisoner-api/allocations/missing-pay-bands.*',
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: [
+        {
+          offenderNo: 'A1234AA',
+          incentiveLevel: 'STD',
+          courseActivityId: 12345,
+          courseActivityDescription: 'Kitchens AM',
+        },
+      ],
+    },
+  })
+
+const stubFindAllocationsWithMissingPayBandsErrors = (): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/nomis-prisoner-api/allocations/missing-pay-bands.*',
+    },
+    response: {
+      status: 500,
+    },
+  })
+
 export default {
   stubNomisPrisonerPing,
   stubGetVisitMigrationEstimatedCount,
@@ -328,4 +359,6 @@ export default {
   stubGetPrisonIncentiveLevelsErrors,
   stubFindSuspendedAllocations,
   stubFindSuspendedAllocationsErrors,
+  stubFindAllocationsWithMissingPayBands,
+  stubFindAllocationsWithMissingPayBandsErrors,
 }

--- a/integration_tests/pages/activities-migration/startActivitiesMigrationPreview.ts
+++ b/integration_tests/pages/activities-migration/startActivitiesMigrationPreview.ts
@@ -33,5 +33,7 @@ export default class StartActivitiesMigrationPage extends Page {
 
   nomisSuspendedAllocations = () => cy.get('#nomisSuspendedAllocations')
 
+  nomisAllocationsWithNoPayBands = () => cy.get('#nomisAllocationsMissingPayBands')
+
   errorSummary = () => cy.get('.govuk-error-summary')
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -47,6 +47,7 @@ declare module 'express-session' {
     dpsPayBandsExist: boolean | null
     dpsPrisonRegimeExists: boolean | null
     suspendedAllocations: string[]
+    allocationsMissingPayBands: string[]
   }
 
   interface StartAllocationsMigrationForm extends MigrationForm {

--- a/server/@types/nomisPrisoner/index.d.ts
+++ b/server/@types/nomisPrisoner/index.d.ts
@@ -14,3 +14,4 @@ export type GetAllocationsByFilter = Omit<operations['findActiveAllocations']['p
 export type VisitRoomCountResponse = components['schemas']['VisitRoomCountResponse']
 export type IncentiveLevel = components['schemas']['IncentiveLevel']
 export type FindSuspendedAllocationsResponse = components['schemas']['FindSuspendedAllocationsResponse']
+export type FindAllocationsMissingPayBandsResponse = components['schemas']['FindAllocationsMissingPayBandsResponse']

--- a/server/routes/activitiesMigration/activitiesMigrationController.test.ts
+++ b/server/routes/activitiesMigration/activitiesMigrationController.test.ts
@@ -167,6 +167,26 @@ describe('activitiesMigrationController', () => {
         { courseActivityDescription: 'Kitchens PM', courseActivityId: 12345, offenderNo: 'B1234BB' },
         { courseActivityDescription: 'Kitchens AM', courseActivityId: 12346, offenderNo: 'A1234AA' },
       ])
+      nomisPrisonerService.findAllocationsWithMissingPayBands.mockResolvedValue([
+        {
+          courseActivityDescription: 'Kitchens PM',
+          courseActivityId: 12345,
+          offenderNo: 'A1234AA',
+          incentiveLevel: 'STD',
+        },
+        {
+          courseActivityDescription: 'Kitchens PM',
+          courseActivityId: 12345,
+          offenderNo: 'B1234BB',
+          incentiveLevel: 'STD',
+        },
+        {
+          courseActivityDescription: 'Kitchens AM',
+          courseActivityId: 12346,
+          offenderNo: 'A1234AA',
+          incentiveLevel: 'BAS',
+        },
+      ])
     })
 
     describe('with validation error', () => {
@@ -280,6 +300,12 @@ describe('activitiesMigrationController', () => {
           `Kitchens AM, 12346, A1234AA,`,
           `Kitchens PM, 12345, A1234AA,`,
           `Kitchens PM, 12345, B1234BB,`,
+        ])
+        expect(req.session.startActivitiesMigrationForm.allocationsMissingPayBands).toEqual([
+          `Activity Description, Activity ID, Prisoner Number, Incentive Level,`,
+          `Kitchens AM, 12346, A1234AA, BAS,`,
+          `Kitchens PM, 12345, A1234AA, STD,`,
+          `Kitchens PM, 12345, B1234BB, STD,`,
         ])
         expect(res.redirect).toHaveBeenCalledWith('/activities-migration/start/preview')
       })

--- a/server/services/nomisPrisonerService.ts
+++ b/server/services/nomisPrisonerService.ts
@@ -10,6 +10,7 @@ import {
   PageAdjudicationIdResponse,
   GetAdjudicationChargeIdsByFilter,
   IncentiveLevel,
+  FindAllocationsMissingPayBandsResponse,
 } from '../@types/nomisPrisoner'
 import logger from '../../logger'
 import { Context } from './nomisMigrationService'
@@ -119,8 +120,27 @@ export default class NomisPrisonerService {
       excludeProgramCodes: activityCategories,
     }
 
-    return NomisPrisonerService.restClient(context.token).get<FindSuspendedAllocationsResponse[]>({
+    const token = await this.hmppsAuthClient.getSystemClientToken(context.username)
+    return NomisPrisonerService.restClient(token).get<FindSuspendedAllocationsResponse[]>({
       path: `/allocations/suspended`,
+      query: querystring.stringify(queryParams),
+    })
+  }
+
+  async findAllocationsWithMissingPayBands(
+    filter: ActivitiesMigrationFilter,
+    activityCategories: string[],
+    context: Context,
+  ): Promise<FindAllocationsMissingPayBandsResponse[]> {
+    logger.info(`finding allocations with missing pay bands for activities migration`)
+    const queryParams = {
+      ...filter,
+      excludeProgramCodes: activityCategories,
+    }
+
+    const token = await this.hmppsAuthClient.getSystemClientToken(context.username)
+    return NomisPrisonerService.restClient(token).get<FindAllocationsMissingPayBandsResponse[]>({
+      path: `/allocations/missing-pay-bands`,
       query: querystring.stringify(queryParams),
     })
   }

--- a/server/views/pages/activities/startActivitiesMigrationPreview.njk
+++ b/server/views/pages/activities/startActivitiesMigrationPreview.njk
@@ -31,7 +31,7 @@
                 <div class="govuk-grid-column-full">
                     <h1 class="govuk-heading-l govuk-!-margin-top-7" id="startActivitiesMigrationPreviewPage">Start a new activities migration - preview</h1>
                 </div>
-                <div class="govuk-grid-column-two-thirds">
+                <div class="govuk-grid-column-three-quarters">
                     {% if form.estimatedCount %}
                         {% set html %}
                             <p class="govuk-notification-banner__heading" id="estimateSummary">
@@ -67,6 +67,13 @@
                                     Found suspended allocations in NOMIS for prison {{ form.prisonId }}.
                                     <a href="#" id='copy-suspended-link'">Copy</a>
                                     <textarea class="govuk-visually-hidden" id="copy-suspended-text" rows="{{ form.suspendedAllocations|length }}" cols="200" readonly>{{ form.suspendedAllocations|join("\n") }}</textarea>
+                                </p>
+                            {% endif %}
+                            {% if form.allocationsMissingPayBands|length %}
+                                <p class="govuk-notification-banner__heading" id="nomisAllocationsMissingPayBands">
+                                    Found allocations missing pay bands in NOMIS for prison {{ form.prisonId }}.
+                                    <a href="#" id='copy-missing-pay-band-link'">Copy</a>
+                                    <textarea class="govuk-visually-hidden" id="copy-missing-pay-band-text" rows="{{ form.allocationsMissingPayBands|length }}" cols="200" readonly>{{ form.allocationsMissingPayBands|join("\n") }}</textarea>
                                 </p>
                             {% endif %}
                         {% endset %}

--- a/server/views/pages/activities/startActivitiesMigrationPreview.njk
+++ b/server/views/pages/activities/startActivitiesMigrationPreview.njk
@@ -63,18 +63,26 @@
                                 </p>
                             {% endif %}
                             {% if form.suspendedAllocations|length %}
-                                <p class="govuk-notification-banner__heading" id="nomisSuspendedAllocations">
-                                    Found suspended allocations in NOMIS for prison {{ form.prisonId }}.
-                                    <a href="#" id='copy-suspended-link'">Copy</a>
-                                    <textarea class="govuk-visually-hidden" id="copy-suspended-text" rows="{{ form.suspendedAllocations|length }}" cols="200" readonly>{{ form.suspendedAllocations|join("\n") }}</textarea>
-                                </p>
+                                <span>
+                                    <p class="govuk-notification-banner__heading" id="nomisSuspendedAllocations">
+                                        Found suspended allocations in NOMIS for prison {{ form.prisonId }}.
+                                        <a href="#" id='copy-suspended-link'">Copy</a>
+                                        <span class="govuk-visually-hidden result-success" id="copy-suspended-confirmed">OK</span>
+                                        <span class="govuk-visually-hidden result-error" id="copy-suspended-failed">Fail</span>
+                                        <textarea class="govuk-visually-hidden" id="copy-suspended-text" rows="{{ form.suspendedAllocations|length }}" cols="200" readonly>{{ form.suspendedAllocations|join("\n") }}</textarea>
+                                    </p>
+                                </span>
                             {% endif %}
                             {% if form.allocationsMissingPayBands|length %}
-                                <p class="govuk-notification-banner__heading" id="nomisAllocationsMissingPayBands">
-                                    Found allocations missing pay bands in NOMIS for prison {{ form.prisonId }}.
-                                    <a href="#" id='copy-missing-pay-band-link'">Copy</a>
-                                    <textarea class="govuk-visually-hidden" id="copy-missing-pay-band-text" rows="{{ form.allocationsMissingPayBands|length }}" cols="200" readonly>{{ form.allocationsMissingPayBands|join("\n") }}</textarea>
-                                </p>
+                                <span>
+                                    <p class="govuk-notification-banner__heading" id="nomisAllocationsMissingPayBands">
+                                        Found allocations missing pay bands in NOMIS for prison {{ form.prisonId }}.
+                                        <a href="#" id='copy-missing-pay-band-link'">Copy</a>
+                                        <span class="govuk-visually-hidden result-success" id="copy-missing-pay-band-confirmed">OK</span>
+                                        <span class="govuk-visually-hidden result-error" id="copy-missing-pay-band-failed">Fail</span>
+                                        <textarea class="govuk-visually-hidden" id="copy-missing-pay-band-text" rows="{{ form.allocationsMissingPayBands|length }}" cols="200" readonly>{{ form.allocationsMissingPayBands|join("\n") }}</textarea>
+                                    </p>
+                                </span>
                             {% endif %}
                         {% endset %}
 


### PR DESCRIPTION
If there are allocations with missing pay bands we see a Copy link, and clicking shows a confirmation:
![image](https://github.com/ministryofjustice/hmpps-nomis-sync-dashboard/assets/58170926/9029b0b0-df55-4eaa-8323-d83a13a7041b)

The clipboard now contains something like:
```
Activity Description, Activity ID, Prisoner Number, Incentive Level,
Barbering R1 AM, 150088, G9656GP, BAS,
Breakfast Packs Workshop 18 AM, 130786, G3062VA, EN2,
Breakfast Packs Workshop 18 AM, 166399, G3062VA, EN2,
Breakfast Packs Workshop 18 PM, 130787, G3062VA, EN2,
Cleaner HB3 AM, 150247, G9256UX, EN2,
...etc
```