### PR TITLE
SDIT-1352 Add check for pay rates with unknown incentives

### DIFF
--- a/assets/js/page-enhancements.js
+++ b/assets/js/page-enhancements.js
@@ -12,7 +12,7 @@ window.pageEnhancements = (($, document) => {
     if (!document.getElementById('startActivitiesMigrationPreviewPage')) {
       return
     }
-    const copyLinkPrefixes = ['copy-suspended', 'copy-missing-pay-band']
+    const copyLinkPrefixes = ['copy-suspended', 'copy-missing-pay-band', 'copy-pay-rates-no-incentive']
 
     async function copyText(copyLinkPrefix) {
       clearConfirmations()

--- a/integration_tests/e2e/startActivitiesMigration.cy.ts
+++ b/integration_tests/e2e/startActivitiesMigration.cy.ts
@@ -126,6 +126,7 @@ context('Start Activities Migration', () => {
       cy.task('stubGetDpsPrisonRegime')
       cy.task('stubFindSuspendedAllocations')
       cy.task('stubFindAllocationsWithMissingPayBands')
+      cy.task('stubFindPayRatesWithUnknownIncentive')
 
       const page = Page.verifyOnPage(StartActivitiesMigrationPage)
       page.prisonId().type('MDI')
@@ -141,6 +142,7 @@ context('Start Activities Migration', () => {
       previewPage.dpsPrisonRegime().should('exist')
       previewPage.nomisSuspendedAllocations().should('exist')
       previewPage.nomisAllocationsWithNoPayBands().should('exist')
+      previewPage.nomisPayRatesUnknownIncentive().should('exist')
     })
 
     it('Shows errors returned from preview checks', () => {
@@ -160,6 +162,7 @@ context('Start Activities Migration', () => {
       cy.task('stubGetDpsPrisonRegimeErrors')
       cy.task('stubFindSuspendedAllocationsErrors')
       cy.task('stubFindAllocationsWithMissingPayBandsErrors')
+      cy.task('stubFindPayRatesWithUnknownIncentiveErrors')
 
       const page = Page.verifyOnPage(StartActivitiesMigrationPage)
       page.prisonId().type('MDI')
@@ -180,6 +183,7 @@ context('Start Activities Migration', () => {
       previewPage.dpsPrisonRegime().should('not.exist')
       previewPage.nomisSuspendedAllocations().should('not.exist')
       previewPage.nomisAllocationsWithNoPayBands().should('not.exist')
+      previewPage.nomisPayRatesUnknownIncentive().should('not.exist')
     })
 
     it('Turns on NOMIS feature switch if not already active', () => {
@@ -198,6 +202,7 @@ context('Start Activities Migration', () => {
       cy.task('stubGetDpsPrisonRegime')
       cy.task('stubFindSuspendedAllocations')
       cy.task('stubFindAllocationsWithMissingPayBands')
+      cy.task('stubFindPayRatesWithUnknownIncentive')
       cy.task('stubCheckServiceAgencySwitchNotFound')
       cy.task('stubPostServiceAgencySwitch')
       cy.task('stubCheckServiceAgencySwitchAfterNotFound')

--- a/integration_tests/mockApis/nomisPrisonerApi.ts
+++ b/integration_tests/mockApis/nomisPrisonerApi.ts
@@ -432,6 +432,37 @@ const stubFindAllocationsWithMissingPayBandsErrors = (): SuperAgentRequest =>
     },
   })
 
+const stubFindPayRatesWithUnknownIncentive = (): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/nomis-prisoner-api/activities/rates-with-unknown-incentives.*',
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: [
+        {
+          courseActivityId: 12345,
+          courseActivityDescription: 'Kitchens AM',
+          payBandCode: '5',
+          incentiveLevel: 'STD',
+        },
+      ],
+    },
+  })
+
+const stubFindPayRatesWithUnknownIncentiveErrors = (): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/nomis-prisoner-api/activities/rates-with-unknown-incentives.*',
+    },
+    response: {
+      status: 500,
+    },
+  })
+
 export default {
   stubNomisPrisonerPing,
   stubGetVisitMigrationEstimatedCount,
@@ -451,4 +482,6 @@ export default {
   stubFindSuspendedAllocationsErrors,
   stubFindAllocationsWithMissingPayBands,
   stubFindAllocationsWithMissingPayBandsErrors,
+  stubFindPayRatesWithUnknownIncentive,
+  stubFindPayRatesWithUnknownIncentiveErrors,
 }

--- a/integration_tests/pages/activities-migration/startActivitiesMigrationPreview.ts
+++ b/integration_tests/pages/activities-migration/startActivitiesMigrationPreview.ts
@@ -35,5 +35,7 @@ export default class StartActivitiesMigrationPage extends Page {
 
   nomisAllocationsWithNoPayBands = () => cy.get('#nomisAllocationsMissingPayBands')
 
+  nomisPayRatesUnknownIncentive = () => cy.get('#nomisPayRatesUnknownIncentive')
+
   errorSummary = () => cy.get('.govuk-error-summary')
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -48,6 +48,7 @@ declare module 'express-session' {
     dpsPrisonRegimeExists: boolean | null
     suspendedAllocations: string[]
     allocationsMissingPayBands: string[]
+    payRatesUnknownIncentive: string[]
   }
 
   interface StartAllocationsMigrationForm extends MigrationForm {

--- a/server/@types/nomisPrisoner/index.d.ts
+++ b/server/@types/nomisPrisoner/index.d.ts
@@ -17,3 +17,4 @@ export type PageActivitiesIdResponse = components['schemas']['PageFindActiveActi
 export type PageAllocationsIdResponse = components['schemas']['PageFindActiveAllocationIdsResponse']
 export type FindSuspendedAllocationsResponse = components['schemas']['FindSuspendedAllocationsResponse']
 export type FindAllocationsMissingPayBandsResponse = components['schemas']['FindAllocationsMissingPayBandsResponse']
+export type FindPayRateWithUnknownIncentiveResponse = components['schemas']['FindPayRateWithUnknownIncentiveResponse']

--- a/server/@types/nomisPrisonerImport/index.d.ts
+++ b/server/@types/nomisPrisonerImport/index.d.ts
@@ -646,6 +646,13 @@ export interface paths {
      */
     get: operations['getAdjudicationByCharge']
   }
+  '/activities/rates-with-unknown-incentives': {
+    /**
+     * Find activities with pay rates with unknown incentive level
+     * @description Searches for course activities that have an active pay rate with an unknown incentive level. Requires role NOMIS_ACTIVITIES
+     */
+    get: operations['findRatesWithUnknownIncentiveLevel']
+  }
   '/activities/ids': {
     /**
      * Find paged active activities
@@ -2508,7 +2515,7 @@ export interface components {
        * @description The date the answer is no longer used
        */
       expiryDate?: string
-      nextQuestion?: components['schemas']['QuestionResponse']
+      nextQuestion?: components['schemas']['NextQuestionResponse']
       /**
        * @description If the answer should include a date
        * @example true
@@ -2519,6 +2526,16 @@ export interface components {
        * @example true
        */
       commentRequired: boolean
+    }
+    /** @description Question to be asked following this answer */
+    NextQuestionResponse: {
+      /**
+       * Format: int64
+       * @description The question id
+       */
+      id: number
+      /** @description The question text */
+      question: string
     }
     /** @description List of Questions (and associated Answers) for this Questionnaire */
     QuestionResponse: {
@@ -2589,6 +2606,8 @@ export interface components {
       listSequence: number
       /** @description List of Questions (and associated Answers) for this Questionnaire */
       questions: components['schemas']['QuestionResponse'][]
+      /** @description List of Roles allowed for an offender's participation in an incident */
+      offenderRoles: string[]
       /**
        * Format: date
        * @description The date the questionnaire is no longer used
@@ -3140,8 +3159,15 @@ export interface components {
     }
     /** @description Questions asked for the incident */
     Question: {
+      /**
+       * Format: int32
+       * @description The sequence number of the question for this incident
+       */
+      sequence: number
       /** @description The Question being asked */
       question: string
+      /** @description List of Responses to this question */
+      answers: components['schemas']['Response'][]
     }
     /** @description Requirements for completing the incident report */
     Requirement: {
@@ -3155,6 +3181,18 @@ export interface components {
       staff: components['schemas']['Staff']
       /** @description The reporting location of the staff */
       prisonId: string
+    }
+    /** @description List of Responses to this question */
+    Response: {
+      /**
+       * Format: int64
+       * @description The id of the answer
+       */
+      id: number
+      /** @description The answer text */
+      answer: string
+      /** @description Comment added to the response by recording staff */
+      comment?: string
     }
     /** @description Incident id */
     IncidentIdResponse: {
@@ -3716,6 +3754,30 @@ export interface components {
        * @example 3.2
        */
       rate: number
+    }
+    /** @description Find activities with a pay rate with unknown incentive level */
+    FindPayRateWithUnknownIncentiveResponse: {
+      /**
+       * @description Course description
+       * @example Kitchens AM
+       */
+      courseActivityDescription: string
+      /**
+       * Format: int64
+       * @description Course Activity ID
+       * @example 1234567
+       */
+      courseActivityId: number
+      /**
+       * @description Pay band code
+       * @example 5
+       */
+      payBandCode: string
+      /**
+       * @description Incentive level
+       * @example STD
+       */
+      incentiveLevelCode: string
     }
     /** @description Find active activity ids response */
     FindActiveActivityIdsResponse: {
@@ -8041,6 +8103,48 @@ export interface operations {
       }
       /** @description Adjudication or adjudication charge does not exist */
       404: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  /**
+   * Find activities with pay rates with unknown incentive level
+   * @description Searches for course activities that have an active pay rate with an unknown incentive level. Requires role NOMIS_ACTIVITIES
+   */
+  findRatesWithUnknownIncentiveLevel: {
+    parameters: {
+      query: {
+        /** @description Prison id */
+        prisonId: string
+        /** @description Exclude program codes */
+        excludeProgramCode?: string
+        /** @description Course Activity ID */
+        courseActivityId?: number
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          'application/json': components['schemas']['FindPayRateWithUnknownIncentiveResponse'][]
+        }
+      }
+      /** @description Invalid request */
+      400: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires role NOMIS_ACTIVITIES */
+      403: {
         content: {
           'application/json': components['schemas']['ErrorResponse']
         }

--- a/server/routes/activitiesMigration/activitiesMigrationController.test.ts
+++ b/server/routes/activitiesMigration/activitiesMigrationController.test.ts
@@ -187,6 +187,20 @@ describe('activitiesMigrationController', () => {
           incentiveLevel: 'BAS',
         },
       ])
+      nomisPrisonerService.findPayRatesWithUnknownIncentive.mockResolvedValue([
+        {
+          courseActivityDescription: 'Kitchens AM',
+          courseActivityId: 12346,
+          payBandCode: '6',
+          incentiveLevelCode: 'BAS',
+        },
+        {
+          courseActivityDescription: 'Kitchens PM',
+          courseActivityId: 12345,
+          payBandCode: '5',
+          incentiveLevelCode: 'STD',
+        },
+      ])
     })
 
     describe('with validation error', () => {
@@ -306,6 +320,11 @@ describe('activitiesMigrationController', () => {
           `Kitchens AM, 12346, A1234AA, BAS,`,
           `Kitchens PM, 12345, A1234AA, STD,`,
           `Kitchens PM, 12345, B1234BB, STD,`,
+        ])
+        expect(req.session.startActivitiesMigrationForm.payRatesUnknownIncentive).toEqual([
+          `Activity Description, Activity ID, Pay Band Code, Incentive Level,`,
+          `Kitchens AM, 12346, 6, BAS,`,
+          `Kitchens PM, 12345, 5, STD,`,
         ])
         expect(res.redirect).toHaveBeenCalledWith('/activities-migration/start/preview')
       })

--- a/server/services/nomisPrisonerService.ts
+++ b/server/services/nomisPrisonerService.ts
@@ -15,6 +15,7 @@ import {
   GetAllocationsByFilter,
   PageActivitiesIdResponse,
   PageAllocationsIdResponse,
+  FindPayRateWithUnknownIncentiveResponse,
 } from '../@types/nomisPrisoner'
 import logger from '../../logger'
 import { Context } from './nomisMigrationService'
@@ -173,6 +174,24 @@ export default class NomisPrisonerService {
     const token = await this.hmppsAuthClient.getSystemClientToken(context.username)
     return NomisPrisonerService.restClient(token).get<FindAllocationsMissingPayBandsResponse[]>({
       path: `/allocations/missing-pay-bands`,
+      query: querystring.stringify(queryParams),
+    })
+  }
+
+  async findPayRatesWithUnknownIncentive(
+    filter: ActivitiesMigrationFilter,
+    activityCategories: string[],
+    context: Context,
+  ): Promise<FindPayRateWithUnknownIncentiveResponse[]> {
+    logger.info(`finding activity pay rates with unknown incentives for activities migration`)
+    const queryParams = {
+      ...filter,
+      excludeProgramCodes: activityCategories,
+    }
+
+    const token = await this.hmppsAuthClient.getSystemClientToken(context.username)
+    return NomisPrisonerService.restClient(token).get<FindPayRateWithUnknownIncentiveResponse[]>({
+      path: `/activities/rates-with-unknown-incentives`,
       query: querystring.stringify(queryParams),
     })
   }

--- a/server/views/pages/activities/startActivitiesMigrationPreview.njk
+++ b/server/views/pages/activities/startActivitiesMigrationPreview.njk
@@ -84,6 +84,17 @@
                                     </p>
                                 </span>
                             {% endif %}
+                            {% if form.payRatesUnknownIncentive|length %}
+                                <span>
+                                    <p class="govuk-notification-banner__heading" id="nomisPayRatesUnknownIncentive">
+                                        Found pay rates in NOMIS without an active incentive level for prison {{ form.prisonId }}.
+                                        <a href="#" id='copy-pay-rates-no-incentive-link'">Copy</a>
+                                        <span class="govuk-visually-hidden result-success" id="copy-pay-rates-no-incentive-confirmed">OK</span>
+                                        <span class="govuk-visually-hidden result-error" id="copy-pay-rates-no-incentive-failed">Fail</span>
+                                        <textarea class="govuk-visually-hidden" id="copy-pay-rates-no-incentive-text" rows="{{ form.payRatesUnknownIncentive|length }}" cols="200" readonly>{{ form.payRatesUnknownIncentive|join("\n") }}</textarea>
+                                    </p>
+                                </span>
+                            {% endif %}
                         {% endset %}
 
                         {{ govukNotificationBanner({


### PR DESCRIPTION
If there are pay bands due to be mgirated for inactive incentive levels then we see a Copy link, and clicking it shows a confirmation:
![image](https://github.com/ministryofjustice/hmpps-nomis-sync-dashboard/assets/58170926/cf7a8336-a366-4d1e-8356-16800c61f251)

The clipboard now contains something like:
```
Activity Description, Activity ID, Pay Band Code, Incentive Level,
ED1-ART AM, 159872, 1, ENT,
ED1-ART PM, 159873, 1, ENT,
ED2-RM4 I-MEDIA PM, 156748, 1, ENT,
```