### PR TITLE
SDIT-1356 Add appointment migration preview counts

### DIFF
--- a/assets/js/page-enhancements.js
+++ b/assets/js/page-enhancements.js
@@ -9,10 +9,18 @@
  */
 window.pageEnhancements = (($, document) => {
   const copyTextToClipboard = () => {
-    if (!document.getElementById('startActivitiesMigrationPreviewPage')) {
+    if (
+      !document.getElementById('startActivitiesMigrationPreviewPage') &&
+      !document.getElementById('startAppointmentsMigrationPreviewPage')
+    ) {
       return
     }
-    const copyLinkPrefixes = ['copy-suspended', 'copy-missing-pay-band', 'copy-pay-rates-no-incentive']
+    const copyLinkPrefixes = [
+      'copy-suspended',
+      'copy-missing-pay-band',
+      'copy-pay-rates-no-incentive',
+      'copy-appointment-counts',
+    ]
 
     async function copyText(copyLinkPrefix) {
       clearConfirmations()

--- a/integration_tests/e2e/startAppointmentsMigration.cy.ts
+++ b/integration_tests/e2e/startAppointmentsMigration.cy.ts
@@ -45,6 +45,7 @@ context('Start Appointments Migration', () => {
       cy.task('stubHealth')
       cy.task('stubGetAppointmentsFailures')
       cy.task('stubCheckServiceAgencySwitch', 'APPOINTMENTS')
+      cy.task('stubGetAppointmentCounts')
 
       Page.verifyOnPage(AppointmentsMigrationPage).startNewMigration().click()
       cy.task('stubGetAppointmentsMigrationEstimatedCount', 100_988)
@@ -64,8 +65,9 @@ context('Start Appointments Migration', () => {
         )
 
       previewPage.fromDateRow().contains('2020-03-23')
-      previewPage.fromDateChangeLink().click()
       previewPage.activateFeatureSwitch('HEI').should('not.exist')
+      previewPage.nomisAppointmentCounts().should('exist')
+      previewPage.fromDateChangeLink().click()
 
       // amend the from date
       const amendPage = Page.verifyOnPage(StartAppointmentsMigrationPage)
@@ -95,6 +97,7 @@ context('Start Appointments Migration', () => {
 
       Page.verifyOnPage(AppointmentsMigrationPage).startNewMigration().click()
       cy.task('stubGetAppointmentsMigrationEstimatedCount', 100_988)
+      cy.task('stubGetAppointmentCounts')
 
       const page = Page.verifyOnPage(StartAppointmentsMigrationPage)
       page.prisonIds().type('HEI')
@@ -131,6 +134,7 @@ context('Start Appointments Migration', () => {
 
       Page.verifyOnPage(AppointmentsMigrationPage).startNewMigration().click()
       cy.task('stubGetAppointmentsMigrationEstimatedCount', 100_988)
+      cy.task('stubGetAppointmentCounts')
 
       const page = Page.verifyOnPage(StartAppointmentsMigrationPage)
       page.prisonIds().type('HEI')

--- a/integration_tests/mockApis/nomisPrisonerApi.ts
+++ b/integration_tests/mockApis/nomisPrisonerApi.ts
@@ -463,6 +463,37 @@ const stubFindPayRatesWithUnknownIncentiveErrors = (): SuperAgentRequest =>
     },
   })
 
+const stubGetAppointmentCounts = (): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/nomis-prisoner-api/appointments/counts.*',
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: [
+        {
+          prisonId: 'MSI',
+          eventSubType: 'ACCA',
+          future: false,
+          count: 20,
+        },
+      ],
+    },
+  })
+
+const stubGetAppointmentCountsErrors = (): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/nomis-prisoner-api/appointments/counts.*',
+    },
+    response: {
+      status: 500,
+    },
+  })
+
 export default {
   stubNomisPrisonerPing,
   stubGetVisitMigrationEstimatedCount,
@@ -484,4 +515,6 @@ export default {
   stubFindAllocationsWithMissingPayBandsErrors,
   stubFindPayRatesWithUnknownIncentive,
   stubFindPayRatesWithUnknownIncentiveErrors,
+  stubGetAppointmentCounts,
+  stubGetAppointmentCountsErrors,
 }

--- a/integration_tests/pages/appointments-migration/startAppointmentsMigrationPreview.ts
+++ b/integration_tests/pages/appointments-migration/startAppointmentsMigrationPreview.ts
@@ -20,4 +20,6 @@ export default class StartAppointmentsMigrationPage extends Page {
   nomisFeatureSwitch = (prisonId: string) => cy.get(`#nomisFeatureSwitch-${prisonId}`)
 
   activateFeatureSwitch = (prisonId: string) => cy.get(`[data-qa=activate-prison-button-${prisonId}]`)
+
+  nomisAppointmentCounts = () => cy.get('#nomisAppointmentCounts')
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -37,6 +37,7 @@ declare module 'express-session' {
     toDate?: string
     prisonIds?: string
     prisonsNotSwitchedOnNomis: string[]
+    appointmentCounts: string[]
   }
 
   interface StartActivitiesMigrationForm extends MigrationForm {

--- a/server/@types/nomisPrisoner/index.d.ts
+++ b/server/@types/nomisPrisoner/index.d.ts
@@ -18,3 +18,4 @@ export type PageAllocationsIdResponse = components['schemas']['PageFindActiveAll
 export type FindSuspendedAllocationsResponse = components['schemas']['FindSuspendedAllocationsResponse']
 export type FindAllocationsMissingPayBandsResponse = components['schemas']['FindAllocationsMissingPayBandsResponse']
 export type FindPayRateWithUnknownIncentiveResponse = components['schemas']['FindPayRateWithUnknownIncentiveResponse']
+export type AppointmentCountsResponse = components['schemas']['AppointmentCountsResponse']

--- a/server/@types/nomisPrisonerImport/index.d.ts
+++ b/server/@types/nomisPrisonerImport/index.d.ts
@@ -562,6 +562,13 @@ export interface paths {
      */
     get: operations['getAppointmentsByFilter']
   }
+  '/appointments/counts': {
+    /**
+     * Get appointment counts by prison, event sub type and future / past. Note that the 'future' is everything from tomorrow onwards.
+     * @description Retrieves counts of appointments for the migration preview. Requires ROLE_NOMIS_APPOINTMENTS.
+     */
+    get: operations['getAppointmentCounts']
+  }
   '/appointments/booking/{bookingId}/location/{locationId}/start/{dateTime}': {
     /**
      * Get an appointment
@@ -2372,14 +2379,14 @@ export interface components {
       totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['VisitIdResponse'][]
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
@@ -2633,14 +2640,14 @@ export interface components {
       totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['QuestionnaireIdResponse'][]
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
@@ -2813,14 +2820,14 @@ export interface components {
       totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['PrisonerId'][]
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
@@ -3098,18 +3105,56 @@ export interface components {
       totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['NonAssociationIdResponse'][]
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
       empty?: boolean
+    }
+    /** @description Historical questionnaire details for the incident */
+    History: {
+      /**
+       * Format: int64
+       * @description The historical incident questionnaire id
+       */
+      questionnaireId: number
+      /** @description The historical incident questionnaire code */
+      questionnaire: string
+      /** @description The historical incident questionnaire description */
+      description?: string
+      /** @description Questions asked for the historical incident questionnaire */
+      questions: components['schemas']['HistoryQuestion'][]
+    }
+    /** @description Questions asked for the historical incident questionnaire */
+    HistoryQuestion: {
+      /**
+       * Format: int32
+       * @description The sequence number of the historical question for this incident
+       */
+      sequence: number
+      /** @description The Question being asked */
+      question: string
+      /** @description Historical list of Responses to this question */
+      answers: components['schemas']['HistoryResponse'][]
+    }
+    /** @description Historical list of Responses to this question */
+    HistoryResponse: {
+      /**
+       * Format: int32
+       * @description The sequence number of the answer
+       */
+      sequence: number
+      /** @description The answer text */
+      answer: string
+      /** @description Comment added to the response by recording staff */
+      comment?: string
     }
     /** @description Incident Details */
     IncidentResponse: {
@@ -3140,15 +3185,17 @@ export interface components {
        */
       reportedDateTime: string
       /** @description Staff involved in the incident */
-      staffParties: components['schemas']['Staff'][]
+      staffParties: components['schemas']['StaffParty'][]
       /** @description Offenders involved in the incident */
-      offenderParties: components['schemas']['Offender'][]
+      offenderParties: components['schemas']['OffenderParty'][]
       /** @description Requirements for completing the incident report */
       requirements: components['schemas']['Requirement'][]
       /** @description Questions asked for the incident */
       questions: components['schemas']['Question'][]
+      /** @description Historical questionnaire details for the incident */
+      history: components['schemas']['History'][]
     }
-    /** @description Offenders involved in the incident */
+    /** @description Offender involved in the incident */
     Offender: {
       /** @description NOMIS id */
       offenderNo: string
@@ -3156,6 +3203,14 @@ export interface components {
       firstName?: string
       /** @description Last name of staff member */
       lastName: string
+    }
+    /** @description Offenders involved in the incident */
+    OffenderParty: {
+      offender: components['schemas']['Offender']
+      role: components['schemas']['CodeDescription']
+      outcome?: components['schemas']['CodeDescription']
+      /** @description General information about the incident */
+      comment?: string
     }
     /** @description Questions asked for the incident */
     Question: {
@@ -3194,6 +3249,13 @@ export interface components {
       /** @description Comment added to the response by recording staff */
       comment?: string
     }
+    /** @description Staff involved in the incident */
+    StaffParty: {
+      staff: components['schemas']['Staff']
+      role: components['schemas']['CodeDescription']
+      /** @description General information about the incident */
+      comment?: string
+    }
     /** @description Incident id */
     IncidentIdResponse: {
       /**
@@ -3207,14 +3269,14 @@ export interface components {
       totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['IncidentIdResponse'][]
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
@@ -3238,14 +3300,14 @@ export interface components {
       totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['IncentiveIdResponse'][]
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
@@ -3345,18 +3407,32 @@ export interface components {
       totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['AppointmentIdResponse'][]
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
       empty?: boolean
+    }
+    /** @description Appointment counts */
+    AppointmentCountsResponse: {
+      /** @description The prison id */
+      prisonId: string
+      /** @description The event sub type */
+      eventSubType: string
+      /** @description Future appointments? */
+      future: boolean
+      /**
+       * Format: int64
+       * @description The count
+       */
+      count: number
     }
     /** @description Allocation to an activity */
     GetAllocationResponse: {
@@ -3544,14 +3620,14 @@ export interface components {
       totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['FindActiveAllocationIdsResponse'][]
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
@@ -3572,14 +3648,14 @@ export interface components {
       totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['AdjustmentIdResponse'][]
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
@@ -3605,14 +3681,14 @@ export interface components {
       totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['AdjudicationChargeIdResponse'][]
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
@@ -3793,14 +3869,14 @@ export interface components {
       totalPages?: number
       /** Format: int64 */
       totalElements?: number
-      first?: boolean
-      last?: boolean
       /** Format: int32 */
       size?: number
       content?: components['schemas']['FindActiveActivityIdsResponse'][]
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
+      first?: boolean
+      last?: boolean
       /** Format: int32 */
       numberOfElements?: number
       pageable?: components['schemas']['PageableObject']
@@ -7566,6 +7642,51 @@ export interface operations {
       200: {
         content: {
           'application/json': components['schemas']['PageAppointmentIdResponse']
+        }
+      }
+      /** @description Unauthorized to access this endpoint */
+      401: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden to access this endpoint when role not present */
+      403: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  /**
+   * Get appointment counts by prison, event sub type and future / past. Note that the 'future' is everything from tomorrow onwards.
+   * @description Retrieves counts of appointments for the migration preview. Requires ROLE_NOMIS_APPOINTMENTS.
+   */
+  getAppointmentCounts: {
+    parameters: {
+      query: {
+        /**
+         * @description Filter results by prison ids
+         * @example ['MDI','LEI']
+         */
+        prisonIds: string[]
+        /**
+         * @description Filter results by appointments that were created on or after the given date
+         * @example 2021-11-03
+         */
+        fromDate?: string
+        /**
+         * @description Filter results by appointments that were created on or before the given date
+         * @example 2022-04-11
+         */
+        toDate?: string
+      }
+    }
+    responses: {
+      /** @description Appointment counts returned */
+      200: {
+        content: {
+          'application/json': components['schemas']['AppointmentCountsResponse'][]
         }
       }
       /** @description Unauthorized to access this endpoint */

--- a/server/routes/appointmentsMigration/appointmentsMigrationController.test.ts
+++ b/server/routes/appointmentsMigration/appointmentsMigrationController.test.ts
@@ -141,6 +141,7 @@ describe('appointmentsMigrationController', () => {
       nomisPrisonerService.getAppointmentsMigrationEstimatedCount.mockResolvedValue(10)
       nomisMigrationService.getAppointmentsDLQMessageCount.mockResolvedValue('20')
       nomisPrisonerService.checkServiceAgencySwitch.mockResolvedValue(true)
+      nomisPrisonerService.findAppointmentCounts.mockResolvedValue([])
     })
 
     describe('with validation error', () => {
@@ -168,6 +169,12 @@ describe('appointmentsMigrationController', () => {
             userMessage: 'Service unavailable',
           },
         })
+        nomisPrisonerService.findAppointmentCounts.mockRejectedValue({
+          data: {
+            status: 400,
+            userMessage: 'Invalid from date: 2023-02-31',
+          },
+        })
         req.body = {
           _csrf: 'ArcKbKvR-OU86UdNwW8RgAGJjIQ9N081rlgM',
           action: 'startMigration',
@@ -182,6 +189,7 @@ describe('appointmentsMigrationController', () => {
         expect(req.flash).toBeCalledWith('errors', [
           { href: '', text: 'Failed to check if APPOINTMENTS feature switch turned on for XXX: Service unavailable' },
           { href: '', text: 'Failed to check if APPOINTMENTS feature switch turned on for YYY: Service unavailable' },
+          { href: '', text: 'Failed to find appointment summary counts due to error: Invalid from date: 2023-02-31' },
         ])
         expect(res.redirect).toHaveBeenCalledWith('/appointments-migration/start/preview')
       })

--- a/server/services/nomisPrisonerService.test.ts
+++ b/server/services/nomisPrisonerService.test.ts
@@ -473,4 +473,85 @@ describe('NomisPrisonerService tests', () => {
       }).rejects.toThrow()
     })
   })
+
+  describe('findAppointmentsCounts', () => {
+    beforeEach(() => {
+      hmppsAuthClient = new HmppsAuthClient({} as TokenStore) as jest.Mocked<HmppsAuthClient>
+      nomisPrisonerService = new NomisPrisonerService(hmppsAuthClient)
+    })
+    it('should return appointment counts', async () => {
+      fakeNomisPrisonerService
+        .get('/appointments/counts')
+        .query({ prisonIds: ['BXI', 'MDI'] })
+        .reply(200, [
+          {
+            prisonId: 'BXI',
+            eventSubType: 'ACTI',
+            future: false,
+            count: 5,
+          },
+          {
+            prisonId: 'BXI',
+            eventSubType: 'ACTI',
+            future: true,
+            count: 7,
+          },
+          {
+            prisonId: 'BXI',
+            eventSubType: 'CABA',
+            future: false,
+            count: 9,
+          },
+          {
+            prisonId: 'MDI',
+            eventSubType: 'ACTI',
+            future: false,
+            count: 12,
+          },
+        ])
+
+      const response = await nomisPrisonerService.findAppointmentCounts(
+        { prisonIds: ['BXI', 'MDI'] },
+        { token: 'some token' },
+      )
+
+      expect(response).toEqual([
+        {
+          prisonId: 'BXI',
+          eventSubType: 'ACTI',
+          future: false,
+          count: 5,
+        },
+        {
+          prisonId: 'BXI',
+          eventSubType: 'ACTI',
+          future: true,
+          count: 7,
+        },
+        {
+          prisonId: 'BXI',
+          eventSubType: 'CABA',
+          future: false,
+          count: 9,
+        },
+        {
+          prisonId: 'MDI',
+          eventSubType: 'ACTI',
+          future: false,
+          count: 12,
+        },
+      ])
+    })
+    it('should throw for any error', () => {
+      fakeNomisPrisonerService
+        .get('/appointments/counts')
+        .query({ prisonIds: ['BXI', 'MDI'] })
+        .reply(504, { message: 'Gateway Timeout' })
+        .persist(true)
+
+      expect(async () => {
+        await nomisPrisonerService.findAppointmentCounts({ prisonIds: ['BXI', 'MDI'] }, { token: 'some token' })
+      }).rejects.toThrow()
+    })
+  })
 })

--- a/server/services/nomisPrisonerService.ts
+++ b/server/services/nomisPrisonerService.ts
@@ -16,11 +16,12 @@ import {
   PageActivitiesIdResponse,
   PageAllocationsIdResponse,
   FindPayRateWithUnknownIncentiveResponse,
+  AppointmentCountsResponse,
 } from '../@types/nomisPrisoner'
 import logger from '../../logger'
 import { Context } from './nomisMigrationService'
 import type HmppsAuthClient from '../data/hmppsAuthClient'
-import type { ActivitiesMigrationFilter } from '../@types/migration'
+import type { ActivitiesMigrationFilter, AppointmentsMigrationFilter } from '../@types/migration'
 import type { FindSuspendedAllocationsResponse } from '../@types/nomisPrisoner'
 
 export default class NomisPrisonerService {
@@ -193,6 +194,18 @@ export default class NomisPrisonerService {
     return NomisPrisonerService.restClient(token).get<FindPayRateWithUnknownIncentiveResponse[]>({
       path: `/activities/rates-with-unknown-incentives`,
       query: querystring.stringify(queryParams),
+    })
+  }
+
+  async findAppointmentCounts(
+    filter: AppointmentsMigrationFilter,
+    context: Context,
+  ): Promise<AppointmentCountsResponse[]> {
+    logger.info(`finding appointments summary counts for appointments migration`)
+    const token = await this.hmppsAuthClient.getSystemClientToken(context.username)
+    return NomisPrisonerService.restClient(token).get<AppointmentCountsResponse[]>({
+      path: `/appointments/counts`,
+      query: querystring.stringify({ ...filter }),
     })
   }
 }

--- a/server/views/pages/appointments/startAppointmentsMigrationPreview.njk
+++ b/server/views/pages/appointments/startAppointmentsMigrationPreview.njk
@@ -29,7 +29,7 @@
         <div class="govuk-width-container">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full">
-                    <h1 class="govuk-heading-l govuk-!-margin-top-7">Start a new appointments migration - preview</h1>
+                    <h1 class="govuk-heading-l govuk-!-margin-top-7" id="startAppointmentsMigrationPreviewPage">Start a new appointments migration - preview</h1>
                 </div>
                 <div class="govuk-grid-column-two-thirds">
                     {% if form.estimatedCount %}
@@ -44,6 +44,17 @@
                                     <a href="{{ activate_prison_link }}" data-qa="activate-prison-button-{{ prisonId }}">Activate prison</a>
                                 </p>
                             {% endfor %}
+                            {% if form.appointmentCounts|length %}
+                                <span>
+                                    <p class="govuk-notification-banner__heading" id="nomisAppointmentCounts">
+                                        Summarised appointment counts for prisons {{ form.prisonIds }}.
+                                        <a href="#" id='copy-appointment-counts-link'">Copy</a>
+                                        <span class="govuk-visually-hidden result-success copy-link-confirmation" id="copy-appointment-counts-confirmed">OK</span>
+                                        <span class="govuk-visually-hidden result-error copy-link-confirmation" id="copy-appointment-counts-failed">Fail</span>
+                                        <textarea class="govuk-visually-hidden" id="copy-appointment-counts-text" rows="{{ form.appointmentCounts|length }}" cols="200" readonly>{{ form.appointmentCounts|join("\n") }}</textarea>
+                                    </p>
+                                </span>
+                            {% endif %}
                         {% endset %}
 
                         {{ govukNotificationBanner({


### PR DESCRIPTION
Add a new Appointments migration preview check to get summaries of appointment counts:
![image](https://github.com/ministryofjustice/hmpps-nomis-sync-dashboard/assets/58170926/894634f7-3942-425f-bce9-5c8369a1bd2e)

Pressing the Copy link copies something like this to the clipboard:
```
Prison, Event Sub Type, Future appointment?, Count,
MDI, ACTI, false, 2707,
MDI, ACTI, true, 20,
MDI, CABA, false, 1068,
MDI, CABE, false, 458,
MDI, CACA, false, 1,
MDI, CAHO, false, 942,
MDI, CALA, false, 1049,
MDI, CANT, false, 6460,
MDI, CAOT, false, 134,
...etc
```