### PR TITLE
SDIT-1501: 🔒️ Grab latest template changes to upgrade to bookworm for vuln

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:20.11-bullseye-slim as base
+FROM node:20.11-bookworm-slim as base
 
 ARG BUILD_NUMBER
 ARG GIT_REF
@@ -36,9 +36,6 @@ FROM base as build
 ARG BUILD_NUMBER
 ARG GIT_REF
 ARG GIT_BRANCH
-
-RUN apt-get update && \
-        apt-get install -y make python g++
 
 COPY package*.json ./
 RUN CYPRESS_INSTALL_BINARY=0 npm ci --no-audit

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "git@github.com:ministryofjustice/hmpps-nomis-sync-dashboard.git",
   "license": "MIT",
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "husky",
     "copy-views": "cp -R server/views dist/server/",
     "compile-sass": "sass --quiet-deps --no-source-map --load-path=node_modules/govuk-frontend/dist --load-path=node_modules/@ministryofjustice/frontend --load-path=. assets/scss/application.scss:./assets/stylesheets/application.css --style compressed",
     "watch-ts": "tsc -w",
@@ -25,7 +25,8 @@
     "security_audit": "npx audit-ci --config audit-ci.json",
     "int-test": "cypress run --config video=false",
     "int-test-ui": "cypress open --e2e --browser chrome",
-    "clean": "rm -rf dist build node_modules stylesheets"
+    "clean": "rm -rf dist build node_modules stylesheets",
+    "rebuild": "npm run clean && npm i && npm run build"
   },
   "engines": {
     "node": "^20",

--- a/server/app.ts
+++ b/server/app.ts
@@ -4,6 +4,7 @@ import createError from 'http-errors'
 
 import nunjucksSetup from './utils/nunjucksSetup'
 import errorHandler from './errorHandler'
+import { appInsightsMiddleware } from './utils/azureAppInsights'
 import authorisationMiddleware from './middleware/authorisationMiddleware'
 
 import setUpAuthentication from './middleware/setUpAuthentication'
@@ -25,6 +26,7 @@ export default function createApp(services: Services): express.Application {
   app.set('trust proxy', true)
   app.set('port', process.env.PORT || 3000)
 
+  app.use(appInsightsMiddleware())
   app.use(setUpHealthChecks(services.applicationInfo))
   app.use(setUpWebSecurity())
   app.use(setUpWebSession())

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -29,9 +29,10 @@ export default function setUpAuth(): Router {
   )
 
   const authUrl = config.apis.hmppsAuth.externalUrl
-  const authSignOutUrl = `${authUrl}/sign-out?client_id=${config.apis.hmppsAuth.apiClientId}&redirect_uri=${config.domain}`
+  const authParameters = `client_id=${config.apis.hmppsAuth.apiClientId}&redirect_uri=${config.domain}`
 
   router.use('/sign-out', (req, res, next) => {
+    const authSignOutUrl = `${authUrl}/sign-out?${authParameters}`
     if (req.user) {
       req.logout(err => {
         if (err) return next(err)
@@ -41,7 +42,7 @@ export default function setUpAuth(): Router {
   })
 
   router.use('/account-details', (req, res) => {
-    res.redirect(`${authUrl}/account-details`)
+    res.redirect(`${authUrl}/account-details?${authParameters}`)
   })
 
   router.use((req, res, next) => {

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -21,8 +21,13 @@ export default function setUpStaticResources(): Router {
     '/node_modules/govuk-frontend/dist',
     '/node_modules/@ministryofjustice/frontend/moj/assets',
     '/node_modules/@ministryofjustice/frontend',
+    '/node_modules/jquery/dist',
   ).forEach(dir => {
     router.use('/assets', express.static(path.join(process.cwd(), dir), cacheControl))
+  })
+
+  Array.of('/node_modules/jquery/dist/jquery.min.js').forEach(dir => {
+    router.use('/assets/js/jquery.min.js', express.static(path.join(process.cwd(), dir), cacheControl))
   })
 
   // Don't cache dynamic resources

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -21,17 +21,8 @@ export default function setUpStaticResources(): Router {
     '/node_modules/govuk-frontend/dist',
     '/node_modules/@ministryofjustice/frontend/moj/assets',
     '/node_modules/@ministryofjustice/frontend',
-    '/node_modules/jquery/dist',
   ).forEach(dir => {
     router.use('/assets', express.static(path.join(process.cwd(), dir), cacheControl))
-  })
-
-  Array.of('/node_modules/govuk_frontend_toolkit/images').forEach(dir => {
-    router.use('/assets/images/icons', express.static(path.join(process.cwd(), dir), cacheControl))
-  })
-
-  Array.of('/node_modules/jquery/dist/jquery.min.js').forEach(dir => {
-    router.use('/assets/js/jquery.min.js', express.static(path.join(process.cwd(), dir), cacheControl))
   })
 
   // Don't cache dynamic resources

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -1,4 +1,11 @@
-import { setup, defaultClient, TelemetryClient, DistributedTracingModes } from 'applicationinsights'
+import {
+  defaultClient,
+  DistributedTracingModes,
+  getCorrelationContext,
+  setup,
+  TelemetryClient,
+} from 'applicationinsights'
+import { RequestHandler } from 'express'
 import type { ApplicationInfo } from '../applicationInfo'
 
 export function initialiseAppInsights(): void {
@@ -17,7 +24,28 @@ export function buildAppInsightsClient(
   if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
     defaultClient.context.tags['ai.cloud.role'] = overrideName || applicationName
     defaultClient.context.tags['ai.application.ver'] = buildNumber
+
+    defaultClient.addTelemetryProcessor(({ tags, data }, contextObjects) => {
+      const operationNameOverride = contextObjects.correlationContext?.customProperties?.getProperty('operationName')
+      if (operationNameOverride) {
+        tags['ai.operation.name'] = data.baseData.name = operationNameOverride // eslint-disable-line no-param-reassign,no-multi-assign
+      }
+      return true
+    })
+
     return defaultClient
   }
   return null
+}
+
+export function appInsightsMiddleware(): RequestHandler {
+  return (req, res, next) => {
+    res.prependOnceListener('finish', () => {
+      const context = getCorrelationContext()
+      if (context && req.route) {
+        context.customProperties.setProperty('operationName', `${req.method} ${req.route?.path}`)
+      }
+    })
+    next()
+  }
 }

--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -28,7 +28,7 @@
       <ul class="hmpps-header__navigation">
         {% if user %}
           <li class="hmpps-header__navigation__item">
-            <a data-qa="manageDetails" class="hmpps-header__link" href="/account-details" data-test="manage-account-link" target="_blank" rel="noopener noreferrer">
+            <a data-qa="manageDetails" class="hmpps-header__link" href="/account-details" data-test="manage-account-link" rel="noopener noreferrer">
               <span data-qa=header-user-name>{{ user.displayName | initialiseName }}</span>
               <span class="hmpps-header__link__sub-text">Manage your details</span>
             </a>


### PR DESCRIPTION
- Use in-memory token store when developing locally (#273)
- Remove getUserRoles as an api call and add as decoded from the token (#274)
- Requre user input when excucting rename script to ensure slack alert channels are set correctly. (#277)
- fix rename project github workflow, correct inputs key. (#278)
- prompt for user input if script is run manually/locally (#279)
- PI-1717 Set session cookie name per-project (#280)
- Ensure product ID is set when bootstraping new projects (#281)
- Update dependencies 2023-12-08 (#282)
- HAAR-2061: Remove deprecated filed (#285)
- Add execute permission back to rename-project.bash script (#286)
- Remove jQueryUI, initialise moj frontend (#288)
- Update Helm release generic-service to 2.9 (#284)
- Update CHANGELOG.md (#275)
- Update all non major NPM dependencies (#271)
- Update dependencies 2023-12-18 (#290)
- Update the breadcrumb partial with display current page title toggle (#291)
- Upgrade to GovUK 5 and MoJ 2.0 (#297)
- SDIT-1411: 🔥 Remove stub user roles as getUserRoles already removed (#298)
- SDIT-1223: 🎨 Document timeout configuration options (#269)
- SDIT-1411: 🔥 Remove shiv as not used anymore (#299)
- Changelog update 2024-01-10 (#300)
- Update all non major NPM dependencies (#294)
- Update MoJ frontend, dropping jQuery which is no longer required (#303)
- Update Nunjucks component paths (#305)
- Update all non major NPM dependencies (#304)
- SDIT-1450: 🐛 Fix manage details link to allow user to return (#307)
- Update all non major NPM dependencies (#309)
- Update all non major NPM dependencies (#310)
- heat-31 update the bootstrap repo name to hmpps-project-bootstrap (#312)
- Update dependencies 2024-02-14 (#314)
- Update peter-evans/create-pull-request action to v6 (#306)
- Update dependency lint-staged to ^15.2.2 (#311)
- PI-1789 added ability to get parameterised paths in app insights for FE (#315)
- Move to Debian 12 / bookworm (#316)
