### PR TITLE
pgp SDIT 1682 upgrades

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ workflows:
     jobs:
       - hmpps/npm_security_audit:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
+          node_tag: << pipeline.parameters.node-version >>
           context:
             - hmpps-common-vars
       - hmpps/trivy_latest_scan:

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,8 @@
         "plugin:prettier/recommended"
       ],
       "rules": {
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": ["error"],
         "@typescript-eslint/no-use-before-define": 0,
         "class-methods-use-this": 0,
         "no-useless-constructor": 0,

--- a/.gitignore
+++ b/.gitignore
@@ -126,4 +126,5 @@ integration_tests/videos/
 integration_tests/screenshots/
 */*.iml
 **/Chart.lock
+**/.DS_Store
 cypress

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "watch-node-feature": "export $(cat feature.env) && nodemon --watch dist/ $NODE_DEBUG_OPTION dist/server.js | bunyan -o short",
     "start-feature:dev": "concurrently -k -p \"[{name}]\" -n \"Views,TypeScript,Node,Sass\" -c \"yellow.bold,cyan.bold,green.bold,blue.bold\" \"npm run watch-views\" \"npm run watch-ts\" \"npm run watch-node-feature\" \"npm run watch-sass\"",
     "lint": "eslint . --cache --max-warnings 0",
+    "lint-fix": "eslint . --cache --max-warnings 0 --fix",
     "typecheck": "tsc && tsc -p integration_tests",
     "test": "TZ=Europe/London jest",
     "test:ci": "TZ=Europe/London jest --runInBand",


### PR DESCRIPTION
- **Update all non major NPM dependencies (#317)**
- **Update dependency nock to ^13.5.3 (#318)**
- **Update all non major NPM dependencies (#319)**
- **Setting node version for security audit and outdate (#321)**
- **Update all non major NPM dependencies (#320)**
- **Update Helm release generic-prometheus-alerts to 1.4 (#322)**
- **Update all non major NPM dependencies (#323)**
- **Add .DS_Store to .gitignore (#324)**
- **add a lint-fix option (#326)**
- **Update all non major NPM dependencies (#325)**
- **Update Helm release generic-service to v3 (#328)**
- **HMPPS Audit setup (#327)**
- **Update all non major NPM dependencies (#330)**
- **Update Helm release generic-service to 3.1 (#332)**
- **Update dependencies 2024-03-26 (#333)**
- **Update dependency govuk-frontend to ^5.3.0 (#334)**
- **Update Node.js to v20.12.0 (#335)**
- **Update dependency prom-client to ^15.1.1 (#336)**
- **Update all non major NPM dependencies (#337)**
- **Update all non major NPM dependencies (#339)**
- **Correcting the MOJ Compliant badge (#340)**
- **Update all non major NPM dependencies (#341)**
