### PR TITLE
Move back links to beforeContent and standardise implementation

### DIFF
--- a/server/views/pages/activities/activitiesMigration.njk
+++ b/server/views/pages/activities/activitiesMigration.njk
@@ -3,18 +3,14 @@
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Activities migration" %}
 {% set bodyAttributes = {'data-page': 'filter-toggle'} %}
+{% set backLinkHref = "/" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/'
-  }) }}
 
   <div class="govuk-grid-row govuk-body">
     <h1 class="govuk-heading-l">Activities migration</h1>

--- a/server/views/pages/activities/activitiesMigrationDetails.njk
+++ b/server/views/pages/activities/activitiesMigrationDetails.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Activities migration details" %}
+{% set backLinkHref = "/activities-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/activities-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/activities/startActivitiesMigration.njk
+++ b/server/views/pages/activities/startActivitiesMigration.njk
@@ -3,15 +3,11 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Start an activities migration" %}
+{% set backLinkHref = "/activities-migration" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/activities-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     {% if errors.length > 0 %}

--- a/server/views/pages/activities/startActivitiesMigrationConfirmation.njk
+++ b/server/views/pages/activities/startActivitiesMigrationConfirmation.njk
@@ -1,15 +1,10 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Activities migration started" %}
+{% set backLinkHref = "/activities-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/activities-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/activities/startActivitiesMigrationPreview.njk
+++ b/server/views/pages/activities/startActivitiesMigrationPreview.njk
@@ -4,19 +4,15 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 
 {% set pageTitle = applicationName + " - Start an activities migration - preview" %}
 {% set bodyAttributes = {'data-page': 'copy-text'} %}
+{% set backLinkHref = "/activities-migration/amend" %}
 
 {% block content %}
-    {{ govukBackLink({
-        text: "Back",
-        href: '/activities-migration/amend'
-    }) }}
 
     <main class="app-container govuk-body">
         {% if errors.length > 0 %}

--- a/server/views/pages/allocations/allocationsMigration.njk
+++ b/server/views/pages/allocations/allocationsMigration.njk
@@ -3,18 +3,14 @@
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Allocations migration" %}
 {% set bodyAttributes = {'data-page': 'filter-toggle'} %}
+{% set backLinkHref = "/" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/'
-  }) }}
 
   <div class="govuk-grid-row govuk-body">
     <h1 class="govuk-heading-l">Allocations migration</h1>

--- a/server/views/pages/allocations/allocationsMigrationDetails.njk
+++ b/server/views/pages/allocations/allocationsMigrationDetails.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Allocations migration details" %}
+{% set backLinkHref = "/allocations-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/allocations-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/allocations/startAllocationsMigration.njk
+++ b/server/views/pages/allocations/startAllocationsMigration.njk
@@ -3,15 +3,11 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Start an allocations migration" %}
+{% set backLinkHref = "/allocations-migration" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/allocations-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     {% if errors.length > 0 %}

--- a/server/views/pages/allocations/startAllocationsMigrationConfirmation.njk
+++ b/server/views/pages/allocations/startAllocationsMigrationConfirmation.njk
@@ -1,15 +1,10 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Allocations migration started" %}
+{% set backLinkHref = "/allocations-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/allocations-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/allocations/startAllocationsMigrationPreview.njk
+++ b/server/views/pages/allocations/startAllocationsMigrationPreview.njk
@@ -4,18 +4,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-
 {% set pageTitle = applicationName + " - Start an allocations migration - preview" %}
+{% set backLinkHref = "/allocations-migration/amend" %}
 
 {% block content %}
-    {{ govukBackLink({
-        text: "Back",
-        href: '/allocations-migration/amend'
-    }) }}
 
     <main class="app-container govuk-body">
         {% if errors.length > 0 %}

--- a/server/views/pages/appointments/appointmentsMigration.njk
+++ b/server/views/pages/appointments/appointmentsMigration.njk
@@ -3,17 +3,13 @@
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% set pageTitle = applicationName + " - Appointments migration" %}
 {% set bodyAttributes = {'data-page': 'filter-toggle'} %}
+{% set backLinkHref = "/" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/'
-  }) }}
 
   <div class="govuk-grid-row govuk-body">
     <h1 class="govuk-heading-l">Appointments migration</h1>

--- a/server/views/pages/appointments/appointmentsMigrationDetails.njk
+++ b/server/views/pages/appointments/appointmentsMigrationDetails.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Appointments migration details" %}
+{% set backLinkHref = "/appointments-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/appointments-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/appointments/appointmentsMigrationFailures.njk
+++ b/server/views/pages/appointments/appointmentsMigrationFailures.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set pageTitle = applicationName + " - Appointments migration failures" %}
+{% set backLinkHref = "/appointments-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/appointments-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/appointments/startAppointmentsMigration.njk
+++ b/server/views/pages/appointments/startAppointmentsMigration.njk
@@ -3,15 +3,11 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Start a appointments migration" %}
+{% set backLinkHref = "/appointments-migration" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/appointments-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     {% if errors.length > 0 %}

--- a/server/views/pages/appointments/startAppointmentsMigrationConfirmation.njk
+++ b/server/views/pages/appointments/startAppointmentsMigrationConfirmation.njk
@@ -1,15 +1,10 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Appointments migration started" %}
+{% set backLinkHref = "/appointments-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/appointments-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/appointments/startAppointmentsMigrationPreview.njk
+++ b/server/views/pages/appointments/startAppointmentsMigrationPreview.njk
@@ -4,19 +4,14 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-
 {% set pageTitle = applicationName + " - Start a appointments migration - preview" %}
 {% set bodyAttributes = {'data-page': 'copy-text'} %}
+{% set backLinkHref = "/appointments-migration/amend" %}
 
 {% block content %}
-    {{ govukBackLink({
-        text: "Back",
-        href: '/appointments-migration/amend'
-    }) }}
 
     <main class="app-container govuk-body">
         {% if errors.length > 0 %}

--- a/server/views/pages/contactperson/contactPersonMigration.njk
+++ b/server/views/pages/contactperson/contactPersonMigration.njk
@@ -3,18 +3,13 @@
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% set pageTitle = applicationName + " - Contact Person migration" %}
 {% set bodyAttributes = {'data-page': 'filter-toggle'} %}
+{% set backLinkHref = "/" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/'
-  }) }}
-
 
   <div class="govuk-grid-row govuk-body">
     <h1 class="govuk-heading-l">Contact Person migration</h1>

--- a/server/views/pages/contactperson/contactPersonMigrationDetails.njk
+++ b/server/views/pages/contactperson/contactPersonMigrationDetails.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Contact Person migration details" %}
+{% set backLinkHref = "/contactperson-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/contactperson-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/contactperson/contactPersonMigrationFailures.njk
+++ b/server/views/pages/contactperson/contactPersonMigrationFailures.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set pageTitle = applicationName + " - Contact Person migration failures" %}
+{% set backLinkHref = "/contactperson-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/contactperson-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/contactperson/profiledetails/contactPersonProfileDetailsMigration.njk
+++ b/server/views/pages/contactperson/profiledetails/contactPersonProfileDetailsMigration.njk
@@ -3,18 +3,14 @@
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Contact Person Profile Details migration" %}
 {% set bodyAttributes = {'data-page': 'filter-toggle'} %}
+{% set backLinkHref = "/" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/'
-  }) }}
 
   <div class="govuk-grid-row govuk-body">
     <h1 class="govuk-heading-l">Contact Person Profile Details migration</h1>

--- a/server/views/pages/contactperson/profiledetails/contactPersonProfileDetailsMigrationDetails.njk
+++ b/server/views/pages/contactperson/profiledetails/contactPersonProfileDetailsMigrationDetails.njk
@@ -1,17 +1,13 @@
 {% extends "../../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Contact Person Profile Details migration details" %}
+{% set backLinkHref = "/contactperson-profiledetails-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/contactperson-profiledetails-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/contactperson/profiledetails/startContactPersonProfileDetailsMigration.njk
+++ b/server/views/pages/contactperson/profiledetails/startContactPersonProfileDetailsMigration.njk
@@ -3,16 +3,12 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 
 {% set pageTitle = applicationName + " - Start a Contact Person Profile Details migration" %}
+{% set backLinkHref = "/contactperson-profiledetails-migration" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/contactperson-profiledetails-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     {% if errors.length > 0 %}

--- a/server/views/pages/contactperson/profiledetails/startContactPersonProfileDetailsMigrationConfirmation.njk
+++ b/server/views/pages/contactperson/profiledetails/startContactPersonProfileDetailsMigrationConfirmation.njk
@@ -1,15 +1,10 @@
 {% extends "../../../partials/layout.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Contact Person Profile Details migration started" %}
+{% set backLinkHref = "/contactperson-profiledetails-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/contactperson-profiledetails-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/contactperson/profiledetails/startContactPersonProfileDetailsMigrationPreview.njk
+++ b/server/views/pages/contactperson/profiledetails/startContactPersonProfileDetailsMigrationPreview.njk
@@ -4,18 +4,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-
 {% set pageTitle = applicationName + " - Start a Contact Person Profile Details migration - preview" %}
+{% set backLinkHref = "/contactperson-profiledetails-migration/amend" %}
 
 {% block content %}
-    {{ govukBackLink({
-        text: "Back",
-        href: '/contactperson-profiledetails-migration/amend'
-    }) }}
 
     <main class="app-container govuk-body">
         {% if errors.length > 0 %}

--- a/server/views/pages/contactperson/startContactPersonMigration.njk
+++ b/server/views/pages/contactperson/startContactPersonMigration.njk
@@ -3,15 +3,11 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Start a Contact Person migration" %}
+{% set backLinkHref = "/contactperson-migration" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/contactperson-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     {% if errors.length > 0 %}

--- a/server/views/pages/contactperson/startContactPersonMigrationConfirmation.njk
+++ b/server/views/pages/contactperson/startContactPersonMigrationConfirmation.njk
@@ -1,15 +1,10 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Contact Person migration started" %}
+{% set backLinkHref = "/contactperson-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/contactperson-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/contactperson/startContactPersonMigrationPreview.njk
+++ b/server/views/pages/contactperson/startContactPersonMigrationPreview.njk
@@ -4,18 +4,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-
 {% set pageTitle = applicationName + " - Start a Contact Person migration - preview" %}
+{% set backLinkHref = "/contactperson-migration/amend" %}
 
 {% block content %}
-    {{ govukBackLink({
-        text: "Back",
-        href: '/contactperson-migration/amend'
-    }) }}
 
     <main class="app-container govuk-body">
         {% if errors.length > 0 %}

--- a/server/views/pages/coreperson/corePersonMigration.njk
+++ b/server/views/pages/coreperson/corePersonMigration.njk
@@ -3,18 +3,13 @@
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% set pageTitle = applicationName + " - Core Person migration" %}
 {% set bodyAttributes = {'data-page': 'filter-toggle'} %}
+{% set backLinkHref = "/" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/'
-  }) }}
-
 
   <div class="govuk-grid-row govuk-body">
     <h1 class="govuk-heading-l">Core Person migration</h1>

--- a/server/views/pages/coreperson/corePersonMigrationDetails.njk
+++ b/server/views/pages/coreperson/corePersonMigrationDetails.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Core Person migration details" %}
+{% set backLinkHref = "/coreperson-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/coreperson-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/coreperson/corePersonMigrationFailures.njk
+++ b/server/views/pages/coreperson/corePersonMigrationFailures.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set pageTitle = applicationName + " - Core Person migration failures" %}
+{% set backLinkHref = "/coreperson-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/coreperson-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/coreperson/startCorePersonMigration.njk
+++ b/server/views/pages/coreperson/startCorePersonMigration.njk
@@ -3,15 +3,11 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Start a Core Person migration" %}
+{% set backLinkHref = "/coreperson-migration" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/coreperson-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     {% if errors.length > 0 %}

--- a/server/views/pages/coreperson/startCorePersonMigrationConfirmation.njk
+++ b/server/views/pages/coreperson/startCorePersonMigrationConfirmation.njk
@@ -1,15 +1,10 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Core Person migration started" %}
+{% set backLinkHref = "/coreperson-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/coreperson-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/coreperson/startCorePersonMigrationPreview.njk
+++ b/server/views/pages/coreperson/startCorePersonMigrationPreview.njk
@@ -4,18 +4,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-
 {% set pageTitle = applicationName + " - Start a Core Person migration - preview" %}
+{% set backLinkHref = "/coreperson-migration/amend" %}
 
 {% block content %}
-    {{ govukBackLink({
-        text: "Back",
-        href: '/coreperson-migration/amend'
-    }) }}
 
     <main class="app-container govuk-body">
         {% if errors.length > 0 %}

--- a/server/views/pages/corporate/corporateMigration.njk
+++ b/server/views/pages/corporate/corporateMigration.njk
@@ -3,18 +3,13 @@
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% set pageTitle = applicationName + " - Corporate migration" %}
 {% set bodyAttributes = {'data-page': 'filter-toggle'} %}
+{% set backLinkHref = "/" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/'
-  }) }}
-
 
   <div class="govuk-grid-row govuk-body">
     <h1 class="govuk-heading-l">Corporate migration</h1>

--- a/server/views/pages/corporate/corporateMigrationDetails.njk
+++ b/server/views/pages/corporate/corporateMigrationDetails.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Corporate migration details" %}
+{% set backLinkHref = "/coreperson-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/corporate-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/corporate/corporateMigrationFailures.njk
+++ b/server/views/pages/corporate/corporateMigrationFailures.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set pageTitle = applicationName + " - Corporate migration failures" %}
+{% set backLinkHref = "/corporate-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/corporate-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/corporate/startCorporateMigration.njk
+++ b/server/views/pages/corporate/startCorporateMigration.njk
@@ -3,15 +3,11 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Start a Corporate migration" %}
+{% set backLinkHref = "/corporate-migration" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/corporate-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     {% if errors.length > 0 %}

--- a/server/views/pages/corporate/startCorporateMigrationConfirmation.njk
+++ b/server/views/pages/corporate/startCorporateMigrationConfirmation.njk
@@ -1,15 +1,10 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Corporate migration started" %}
+{% set backLinkHref = "/corporate-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/corporate-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/corporate/startCorporateMigrationPreview.njk
+++ b/server/views/pages/corporate/startCorporateMigrationPreview.njk
@@ -4,18 +4,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-
 {% set pageTitle = applicationName + " - Start a Corporate migration - preview" %}
+{% set backLinkHref = "/corporate-migration/amend" %}
 
 {% block content %}
-    {{ govukBackLink({
-        text: "Back",
-        href: '/corporate-migration/amend'
-    }) }}
 
     <main class="app-container govuk-body">
         {% if errors.length > 0 %}

--- a/server/views/pages/courtSentencing/courtSentencingMigration.njk
+++ b/server/views/pages/courtSentencing/courtSentencingMigration.njk
@@ -3,17 +3,13 @@
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% set pageTitle = applicationName + " - Court Sentencing migration" %}
 {% set bodyAttributes = {'data-page': 'filter-toggle'} %}
+{% set backLinkHref = "/" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/'
-  }) }}
 
   <div class="govuk-grid-row govuk-body">
     <h1 class="govuk-heading-l">Court Sentencing migration</h1>

--- a/server/views/pages/courtSentencing/courtSentencingMigrationDetails.njk
+++ b/server/views/pages/courtSentencing/courtSentencingMigrationDetails.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Court Sentencing migration details" %}
+{% set backLinkHref = "/court-sentencing-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/court-sentencing-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/courtSentencing/courtSentencingMigrationFailures.njk
+++ b/server/views/pages/courtSentencing/courtSentencingMigrationFailures.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set pageTitle = applicationName + " - Court Sentencing migration failures" %}
+{% set backLinkHref = "/court-sentencing-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/court-sentencing-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/courtSentencing/startCourtSentencingMigration.njk
+++ b/server/views/pages/courtSentencing/startCourtSentencingMigration.njk
@@ -3,15 +3,11 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Start a court sentencing migration" %}
+{% set backLinkHref = "/court-sentencing-migration" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/court-sentencing-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     {% if errors.length > 0 %}

--- a/server/views/pages/courtSentencing/startCourtSentencingMigrationConfirmation.njk
+++ b/server/views/pages/courtSentencing/startCourtSentencingMigrationConfirmation.njk
@@ -1,15 +1,10 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Court Sentencing migration started" %}
+{% set backLinkHref = "/court-sentencing-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/court-sentencing-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/courtSentencing/startCourtSentencingMigrationPreview.njk
+++ b/server/views/pages/courtSentencing/startCourtSentencingMigrationPreview.njk
@@ -4,18 +4,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-
 {% set pageTitle = applicationName + " - Start a court sentencing migration - preview" %}
+{% set backLinkHref = "/court-sentencing-migration/amend" %}
 
 {% block content %}
-    {{ govukBackLink({
-        text: "Back",
-        href: '/court-sentencing-migration/amend'
-    }) }}
 
     <main class="app-container govuk-body">
         {% if errors.length > 0 %}

--- a/server/views/pages/incidents/incidentsMigration.njk
+++ b/server/views/pages/incidents/incidentsMigration.njk
@@ -3,17 +3,13 @@
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% set pageTitle = applicationName + " - Incidents migration" %}
 {% set bodyAttributes = {'data-page': 'filter-toggle'} %}
+{% set backLinkHref = "/" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/'
-  }) }}
 
   <div class="govuk-grid-row govuk-body">
     <h1 class="govuk-heading-l">Incidents migration</h1>

--- a/server/views/pages/incidents/incidentsMigrationDetails.njk
+++ b/server/views/pages/incidents/incidentsMigrationDetails.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Incidents migration details" %}
+{% set backLinkHref = "/incidents-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/incidents-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/incidents/incidentsMigrationFailures.njk
+++ b/server/views/pages/incidents/incidentsMigrationFailures.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set pageTitle = applicationName + " - Incidents migration failures" %}
+{% set backLinkHref = "/incidents-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/incidents-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/incidents/startIncidentsMigration.njk
+++ b/server/views/pages/incidents/startIncidentsMigration.njk
@@ -3,15 +3,11 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Start a incidents migration" %}
+{% set backLinkHref = "/incidents-migration" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/incidents-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     {% if errors.length > 0 %}

--- a/server/views/pages/incidents/startIncidentsMigrationConfirmation.njk
+++ b/server/views/pages/incidents/startIncidentsMigrationConfirmation.njk
@@ -1,15 +1,10 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Incidents migration started" %}
+{% set backLinkHref = "/incidents-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/incidents-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/incidents/startIncidentsMigrationPreview.njk
+++ b/server/views/pages/incidents/startIncidentsMigrationPreview.njk
@@ -4,18 +4,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-
 {% set pageTitle = applicationName + " - Start a incidents migration - preview" %}
+{% set backLinkHref = "/incidents-migration/amend" %}
 
 {% block content %}
-    {{ govukBackLink({
-        text: "Back",
-        href: '/incidents-migration/amend'
-    }) }}
 
     <main class="app-container govuk-body">
         {% if errors.length > 0 %}

--- a/server/views/pages/sentencing/sentencingMigration.njk
+++ b/server/views/pages/sentencing/sentencingMigration.njk
@@ -3,18 +3,13 @@
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% set pageTitle = applicationName + " - Sentencing migration" %}
 {% set bodyAttributes = {'data-page': 'filter-toggle'} %}
+{% set backLinkHref = "/" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/'
-  }) }}
-
 
   <div class="govuk-grid-row govuk-body">
     <h1 class="govuk-heading-l">Sentencing migration</h1>

--- a/server/views/pages/sentencing/sentencingMigrationDetails.njk
+++ b/server/views/pages/sentencing/sentencingMigrationDetails.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Sentencing migration details" %}
+{% set backLinkHref = "/sentencing-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/sentencing-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/sentencing/sentencingMigrationFailures.njk
+++ b/server/views/pages/sentencing/sentencingMigrationFailures.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set pageTitle = applicationName + " - Sentencing migration failures" %}
+{% set backLinkHref = "/sentencing-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/sentencing-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/sentencing/startSentencingMigration.njk
+++ b/server/views/pages/sentencing/startSentencingMigration.njk
@@ -3,15 +3,11 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Start a sentencing migration" %}
+{% set backLinkHref = "/sentencing-migration" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/sentencing-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     {% if errors.length > 0 %}

--- a/server/views/pages/sentencing/startSentencingMigrationConfirmation.njk
+++ b/server/views/pages/sentencing/startSentencingMigrationConfirmation.njk
@@ -1,15 +1,10 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Sentencing migration started" %}
+{% set backLinkHref = "/sentencing-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/sentencing-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/sentencing/startSentencingMigrationPreview.njk
+++ b/server/views/pages/sentencing/startSentencingMigrationPreview.njk
@@ -4,18 +4,14 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-
 {% set pageTitle = applicationName + " - Start a sentencing migration - preview" %}
+{% set backLinkHref = "/sentencing-migration/amend" %}
+
 
 {% block content %}
-    {{ govukBackLink({
-        text: "Back",
-        href: '/sentencing-migration/amend'
-    }) }}
 
     <main class="app-container govuk-body">
         {% if errors.length > 0 %}

--- a/server/views/pages/visitbalance/startVisitBalanceMigration.njk
+++ b/server/views/pages/visitbalance/startVisitBalanceMigration.njk
@@ -3,15 +3,11 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Start a visit balance migration" %}
+{% set backLinkHref = "/visit-balance-migration" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/visit-balance-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     {% if errors.length > 0 %}

--- a/server/views/pages/visitbalance/startVisitBalanceMigrationConfirmation.njk
+++ b/server/views/pages/visitbalance/startVisitBalanceMigrationConfirmation.njk
@@ -1,15 +1,10 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - visit balance migration started" %}
+{% set backLinkHref = "/visit-balance-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/visit-balance-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/visitbalance/startVisitBalanceMigrationPreview.njk
+++ b/server/views/pages/visitbalance/startVisitBalanceMigrationPreview.njk
@@ -4,18 +4,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-
 {% set pageTitle = applicationName + " - Start a visit balance migration - preview" %}
+{% set backLinkHref = "/visit-balance-migration/amend" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/visit-balance-migration/amend'
-  }) }}
 
   <main class="app-container govuk-body">
     {% if errors.length > 0 %}

--- a/server/views/pages/visitbalance/visitBalanceMigration.njk
+++ b/server/views/pages/visitbalance/visitBalanceMigration.njk
@@ -3,18 +3,13 @@
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% set pageTitle = applicationName + " - visit balance migration" %}
 {% set bodyAttributes = {'data-page': 'filter-toggle'} %}
+{% set backLinkHref = "/" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/'
-  }) }}
-
 
   <div class="govuk-grid-row govuk-body">
     <h1 class="govuk-heading-l">Visit balance migration</h1>

--- a/server/views/pages/visitbalance/visitBalanceMigrationDetails.njk
+++ b/server/views/pages/visitbalance/visitBalanceMigrationDetails.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - visit balance migration details" %}
+{% set backLinkHref = "/visit-balance-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/visit-balance-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/visitbalance/visitBalanceMigrationFailures.njk
+++ b/server/views/pages/visitbalance/visitBalanceMigrationFailures.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set pageTitle = applicationName + " - visit balance migration failures" %}
+{% set backLinkHref = "/visit-balance-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/visit-balance-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/visits/addRoomMapping.njk
+++ b/server/views/pages/visits/addRoomMapping.njk
@@ -1,13 +1,14 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitle = applicationName + " - Room mappings" %}
+{% set backLinkHref = "/visits-room-mappings?prisonId=" + prisonId %}
 
 {% block content %}
+
 <div class="app-container govuk-body">
     {% if errors.length > 0 %}
     {{ govukErrorSummary({

--- a/server/views/pages/visits/roomMappingPrison.njk
+++ b/server/views/pages/visits/roomMappingPrison.njk
@@ -1,14 +1,15 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% set pageTitle = applicationName + " - Room mappings" %}
+{% set backLinkHref = "/visits-room-mappings" %}
 
 {% block content %}
+
 <div class="app-container govuk-body">
     {% if errors.length > 0 %}
     {{ govukErrorSummary({

--- a/server/views/pages/visits/startVisitsMigration.njk
+++ b/server/views/pages/visits/startVisitsMigration.njk
@@ -5,16 +5,12 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Start a visits migration" %}
+{% set backLinkHref = "/visits-migration" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/visits-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     {% if errors.length > 0 %}

--- a/server/views/pages/visits/startVisitsMigrationConfirmation.njk
+++ b/server/views/pages/visits/startVisitsMigrationConfirmation.njk
@@ -1,15 +1,10 @@
 {% extends "../../partials/layout.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = applicationName + " - Visits migration started" %}
+{% set backLinkHref = "/visits-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/visits-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/visits/startVisitsMigrationPreview.njk
+++ b/server/views/pages/visits/startVisitsMigrationPreview.njk
@@ -4,18 +4,13 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-
 {% set pageTitle = applicationName + " - Start a visits migration - preview" %}
+{% set backLinkHref = "/visits-migration/amend" %}
 
 {% block content %}
-    {{ govukBackLink({
-        text: "Back",
-        href: '/visits-migration/amend'
-    }) }}
 
     <main class="app-container govuk-body">
         {% if errors.length > 0 %}

--- a/server/views/pages/visits/viewRoomMappings.njk
+++ b/server/views/pages/visits/viewRoomMappings.njk
@@ -3,13 +3,14 @@
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitle = applicationName + " - Room mappings" %}
+{% set backLinkHref = "/visits-room-mappings" %}
 
 {% block content %}
+
 <div class="govuk-grid-row govuk-body">
     <h1 class="govuk-heading-l">Room mappings - {{ prisonId }}</h1>
 

--- a/server/views/pages/visits/visitsMigration.njk
+++ b/server/views/pages/visits/visitsMigration.njk
@@ -3,18 +3,13 @@
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% set pageTitle = applicationName + " - Visits migration" %}
 {% set bodyAttributes = {'data-page': 'filter-toggle'} %}
+{% set backLinkHref = "/" %}
 
 {% block content %}
-  {{ govukBackLink({
-    text: "Back",
-    href: '/'
-  }) }}
-
 
   {% set filterOptionsHtml %}
     <form id="filter-form" action="/visits-migration" novalidate>

--- a/server/views/pages/visits/visitsMigration.njk
+++ b/server/views/pages/visits/visitsMigration.njk
@@ -26,7 +26,7 @@
   {% endset %}
 
 
-  <div class="govuk-grid-row govuk-body">
+  <div class="govuk-width-container">
     <h1 class="govuk-heading-l">Visits migration</h1>
 
     <div>

--- a/server/views/pages/visits/visitsMigrationDetails.njk
+++ b/server/views/pages/visits/visitsMigrationDetails.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Visits migration details" %}
+{% set backLinkHref = "/visits-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/visits-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/pages/visits/visitsMigrationFailures.njk
+++ b/server/views/pages/visits/visitsMigrationFailures.njk
@@ -1,17 +1,12 @@
 {% extends "../../partials/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set pageTitle = applicationName + " - Visits migration failures" %}
+{% set backLinkHref = "/visits-migration" %}
 
 {% block content %}
-
-  {{ govukBackLink({
-    text: "Back",
-    href: '/visits-migration'
-  }) }}
 
   <main class="app-container govuk-body">
     <div class="govuk-width-container">

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,4 +1,5 @@
 {% extends "govuk/template.njk" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block head %}
   <link href="{{ '/assets/css/app.css' | assetMap }}" rel="stylesheet"/>
@@ -13,6 +14,17 @@
 {% endblock %}
 
 {% block bodyStart %}
+{% endblock %}
+
+{% block beforeContent %}
+  <div role="navigation">
+    {% if backLinkHref %}
+      {{ govukBackLink({
+        text: "Back",
+        href: backLinkHref
+      }) }}
+    {% endif %}
+  </div>
 {% endblock %}
 
 {% block bodyEnd %}


### PR DESCRIPTION
This PR moves the back links on pages into the beforeContent block as advised in the GDS Design System. This PR also standardises and simplifies how back links are managed across the pages by moving the component to the layout.njk.

A small fix is also added for a page width issue on one of the visit migration related pages.